### PR TITLE
Update postAttachCommands.sh

### DIFF
--- a/.devcontainer/postAttachCommands.sh
+++ b/.devcontainer/postAttachCommands.sh
@@ -10,5 +10,5 @@ gh codespace ports visibility 7072:public -c $CODESPACE_NAME
 gh codespace ports -c $CODESPACE_NAME >> ~/postAttachCommands.log
 
 # ... and update our envrionment.ts file with the new public URL.
-ADDRESS=`gh codespace ports -c $CODESPACE_NAME -q ".[0] | .browseUrl " --json browseUrl`
+ADDRESS=`gh codespace ports -c $CODESPACE_NAME --json label,browseUrl | jq -r '.[] | select(.label == "backend").browseUrl'`
 sed -i 's|http://localhost:7072|'$ADDRESS'|g' $CODESPACE_VSCODE_FOLDER/ContosoAIAppsFrontend/src/environments/environment.ts


### PR DESCRIPTION
Fixed an error caused by assuming the first element of an array was the backend API URL but it seems this wasn't always the case.